### PR TITLE
Change absolute links to relative links

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -9,8 +9,8 @@ To use LineScript for your webpage, you will need four files: the base.html file
 ```html
 <html id="whole">
  <body onload="build('MY_FILE')" id="line">
-  <script src="https://raw.githubusercontent.com/ntrupin/LineScript/master/src/compiler.js"></script>
-  <script src="https://raw.githubusercontent.com/ntrupin/LineScript/master/src/gate.js"></script>
+  <script src="compiler.js"></script>
+  <script src="gate.js"></script>
  <body>
 </html>
 ```

--- a/src/base.html
+++ b/src/base.html
@@ -1,6 +1,6 @@
 <html id="whole">
  <body onload="build('MY_FILE')" id="line">
-  <script src="https://raw.githubusercontent.com/ntrupin/LineScript/master/src/compiler.js"></script>
-  <script src="https://raw.githubusercontent.com/ntrupin/LineScript/master/src/gate.js"></script>
+  <script src="compiler.js"></script>
+  <script src="gate.js"></script>
  <body>
 </html>


### PR DESCRIPTION
Change absolute links to relative links

I changed the absolute links of `compiler.js` and `gate.js` to relative, as otherwise the code will error (might be specific to my webserver and chrome though) saying that the files are of MIME type `text/plain` and therefore cannot be executed. Also, it specifies in the [docs](https://github.com/ntrupin/LineScript/blob/master/DOCS.md#files) that you need the files, so this is also adhering closer to what the documentation says.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (Not applicable)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
