### PR TITLE
Fix error with `end` command

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -206,12 +206,9 @@ function parse(cv) {
       return output;
       break;
     }
-    break;
-
    // Errors
    case undefined: 
    case null:
-   default:
     output = "MISSING IDENTIFIERS"
     return output;
     break;

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -206,6 +206,8 @@ function parse(cv) {
       return output;
       break;
     }
+    break;
+
    // Errors
    case undefined: 
    case null:


### PR DESCRIPTION
Fix error with `end` command

When I decided to run the [example program](https://github.com/ntrupin/LineScript/blob/master/examples/ugly_yellow.osls), I noticed that it said `MISSING IDENTIFIER`. Having skimmed through the code before hand, I knew this meant some sort of syntax error, however the program was perfectly valid. Then I saw that there was a missing break after the "end" case, and therefore it was also running the default case, which is what made it look like an error.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Not applicable)
- [x] My changes generate no new warnings
