### PR TITLE
Support for multiple arguments, support for iframe

### DIFF
--- a/examples/osls_iframe.osls
+++ b/examples/osls_iframe.osls
@@ -1,0 +1,1 @@
+iframe -> osls="../examples/img_example" width="500" height="900" :: iframe not supported

--- a/examples/ugly_yellow.osls
+++ b/examples/ugly_yellow.osls
@@ -3,4 +3,4 @@ title :: Hello, World!
 div -> style="background-color:yellow" ::
  h1 :: This was written in LineScript!
  p -> onclick="alert('Hi!')" :: Click Me
-end :: div
+end :: div 

--- a/examples/ugly_yellow.osls
+++ b/examples/ugly_yellow.osls
@@ -3,4 +3,4 @@ title :: Hello, World!
 div -> style="background-color:yellow" ::
  h1 :: This was written in LineScript!
  p -> onclick="alert('Hi!')" :: Click Me
-end :: div 
+end :: div

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -1,7 +1,8 @@
 function parse(cv) {
- c = cv.toString().split(" :: ")
- v = c[0].split(" -> ")
- tagname = v[0].replace(/\s/g,'')
+ let c = cv.toString().split(" :: ");
+ let v = c[0].split(" -> ");
+ let args = parse_attributes(v[1]);
+ let tagname = v[0].replace(/\s/g,'');
  switch(tagname) {
   case "h1":// Heading 1
   case "h2":// Heading 2
@@ -82,7 +83,7 @@ function parse(cv) {
       case undefined:
        return `<${tagname} ${v[1]}></${tagname}>`;
        break;
-      default: 
+      default:
        return `<${tagname} ${v[1]}>${c[1]}</${tagname}>`;
        break;
      }
@@ -125,7 +126,7 @@ function parse(cv) {
       link.href = c[1]
       return "";
       break;
-    } 
+    }
    // Style for Body
    case "bodystyle":
     switch(v[1]) {
@@ -155,6 +156,14 @@ function parse(cv) {
       return `<${tagname} ${v[1]} /></${tagname}>`;
       break;
    }
+   // iframe
+  case "iframe":
+      let osls_src="";
+      if(args.hasOwnProperty("osls")){
+          osls_src = encode_html(build_osls(args["osls"]))
+      }
+      return `<${tagname} ${v[1]} srcdoc="${osls_src}" >${c[1]}</${tagname}>`;
+      break;
   case "center":
    switch(v[1]) {
     case undefined:
@@ -183,9 +192,33 @@ function parse(cv) {
     return "";
     break;
    // Errors
-   case undefined: 
+   case undefined:
    case null:
     return "Invalid Syntax";
     break;
  }
+}
+
+function parse_attributes(str) {
+    var regex = /(\w*) *= *((['"])?((\\\3|[^\3])*?)\3|(\w+))/g,
+        attr = {},
+        match;
+    while(match = regex.exec(str)) {
+        attr[match[1]] = match[2].substring(1, match[2].length-1);
+    }
+    return attr;
+}
+
+function encode_html(html){
+    var __entityMap = {
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': '&quot;',
+        "'": '&#39;',
+        "/": '&#x2F;'
+    };
+    return html.replace(/[&<>"'`\/]/g, function (s) {
+        return __entityMap[s];
+    });
 }

--- a/src/gate.js
+++ b/src/gate.js
@@ -1,17 +1,16 @@
-function build(filename) {
- var xmlhttp;
- xmlhttp=new XMLHttpRequest();
- xmlhttp.open('GET', "./" + filename + ".osls", false);
- xmlhttp.send();
- x = xmlhttp.responseText
- y = x.split("\n")
- it = "";
- y.forEach(function(ele) {
-  output = parse(ele)
-  console.log(output)
-  it = it + output
-  console.log(it)
-  document.getElementById("line").innerHTML = it
-console.log(document.getElementById("whole").innerHTML)
- });
+function build(filename,target="#line") {
+    document.querySelector(target).innerHTML = build_osls(filename);
+}
+
+function build_osls(filename) {
+    var xmlhttp=new XMLHttpRequest();
+    xmlhttp.open('GET', "./" + filename + ".osls", false);
+    xmlhttp.send();
+    var x = xmlhttp.responseText;
+    var y = x.split("\n");
+    var it = "";
+    y.forEach(function(ele) {
+        it += parse(ele);
+    });
+    return it;
 }


### PR DESCRIPTION
# Description

 - parse and use multiple arguments using parse_attributes function  you can access with args variable example: <${tagname} src='${args["src"]}' />`
 - new element: iframe which can support osls file source example in examples/osls_iframe.osls
 - more options on gate.js like you can choose the target etc
 

Fixes # (issue)
- minor fixes like variable declarations

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
