### PR TITLE
osls within the html file & more options in gate.js

### DIFF
--- a/examples/osls_iframe.osls
+++ b/examples/osls_iframe.osls
@@ -1,0 +1,1 @@
+iframe -> osls="../examples/img_example" width="500" height="900" :: iframe not supported

--- a/examples/osls_in_html.html
+++ b/examples/osls_in_html.html
@@ -1,0 +1,21 @@
+<html>
+<body onload="auto_build_osls()">
+
+<script src="../src/compiler.js"></script>
+<script src="../src/gate.js"></script>
+
+<script type="text/osls">
+    meta -> charset="utf-8" ::
+    title :: Hello, World!
+    div -> style="background-color:yellow" ::
+     h1 :: This was written in LineScript!
+     p -> onclick="alert('Hi!')" :: Click Me
+    end :: div
+</script>
+
+<script type="text/osls">
+    iframe -> osls="../examples/img_example" width="500" height="900" src="http://sudo-beer.com" :: iframe not supported
+</script>
+
+</body>
+</html>

--- a/examples/ugly_yellow.osls
+++ b/examples/ugly_yellow.osls
@@ -3,4 +3,4 @@ title :: Hello, World!
 div -> style="background-color:yellow" ::
  h1 :: This was written in LineScript!
  p -> onclick="alert('Hi!')" :: Click Me
-end :: div
+end :: div 

--- a/examples/ugly_yellow.osls
+++ b/examples/ugly_yellow.osls
@@ -3,4 +3,4 @@ title :: Hello, World!
 div -> style="background-color:yellow" ::
  h1 :: This was written in LineScript!
  p -> onclick="alert('Hi!')" :: Click Me
-end :: div 
+end :: div

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -159,10 +159,10 @@ function parse(cv) {
    // iframe
   case "iframe":
       let osls_src="";
-      if(args.hasOwnProperty("osls")){
-          osls_src = encode_html(build_osls(args["osls"]))
+      if(args.hasOwnProperty("osls") && args["osls"]){
+          osls_src = encode_html(build(args["osls"]))
       }
-      return `<${tagname} ${v[1]} srcdoc="${osls_src}" >${c[1]}</${tagname}>`;
+      return `<${tagname} ${v[1]} ${osls_src?"srcdoc='"+osls_src+"'":""} >${c[1]}</${tagname}>`;
       break;
   case "center":
    switch(v[1]) {

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -1,7 +1,8 @@
 function parse(cv) {
- c = cv.toString().split(" :: ")
- v = c[0].split(" -> ")
- tagname = v[0].replace(/\s/g,'')
+ let c = cv.toString().split(" :: ");
+ let v = c[0].split(" -> ");
+ let args = parse_attributes(v[1]);
+ let tagname = v[0].replace(/\s/g,'');
  switch(tagname) {
   case "h1":// Heading 1
   case "h2":// Heading 2
@@ -82,7 +83,7 @@ function parse(cv) {
       case undefined:
        return `<${tagname} ${v[1]}></${tagname}>`;
        break;
-      default: 
+      default:
        return `<${tagname} ${v[1]}>${c[1]}</${tagname}>`;
        break;
      }
@@ -125,7 +126,7 @@ function parse(cv) {
       link.href = c[1]
       return "";
       break;
-    } 
+    }
    // Style for Body
    case "bodystyle":
     switch(v[1]) {
@@ -155,6 +156,14 @@ function parse(cv) {
       return `<${tagname} ${v[1]} /></${tagname}>`;
       break;
    }
+   // iframe
+  case "iframe":
+      let osls_src="";
+      if(args.hasOwnProperty("osls")){
+          osls_src = encode_html(build_osls(args["osls"]))
+      }
+      return `<${tagname} ${v[1]} srcdoc="${osls_src}" >${c[1]}</${tagname}>`;
+      break;
   case "center":
    switch(v[1]) {
     case undefined:
@@ -183,9 +192,33 @@ function parse(cv) {
     return "";
     break;
    // Errors
-   case undefined: 
+   case undefined:
    case null:
     return "Invalid Syntax";
     break;
  }
+}
+
+function parse_attributes(str) {
+    var regex = /(\w*) *= *((['"])?((\\\3|[^\3])*?)\3|(\w+))/g,
+        attr = {},
+        match;
+    while(match = regex.exec(str)) {
+        attr[match[1]] = match[2].substring(1, match[2].length-1);
+    }
+    return attr;
+}
+
+function encode_html(html){
+    var __entityMap = {
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': '&quot;',
+        "'": '&#39;',
+        "/": '&#x2F;'
+    };
+    return html.replace(/[&<>"'`\/]/g, function (s) {
+        return __entityMap[s];
+    });
 }

--- a/src/gate.js
+++ b/src/gate.js
@@ -1,17 +1,16 @@
-function build(filename) {
- var xmlhttp;
- xmlhttp=new XMLHttpRequest();
- xmlhttp.open('GET', "./" + filename + ".osls", false);
- xmlhttp.send();
- x = xmlhttp.responseText
- y = x.split("\n")
- it = "";
- y.forEach(function(ele) {
-  output = parse(ele)
-  console.log(output)
-  it = it + output
-  console.log(it)
-  document.getElementById("line").innerHTML = it
-console.log(document.getElementById("whole").innerHTML)
- });
+function build(filename,target="#line") {
+    document.querySelector(target).innerHTML = build_osls(filename);
+}
+
+function build_osls(filename) {
+    var xmlhttp=new XMLHttpRequest();
+    xmlhttp.open('GET', "./" + filename + ".osls", false);
+    xmlhttp.send();
+    var x = xmlhttp.responseText;
+    var y = x.split("\n");
+    var it = "";
+    y.forEach(function(ele) {
+        it += parse(ele);
+    });
+    return it;
 }

--- a/src/gate.js
+++ b/src/gate.js
@@ -1,16 +1,34 @@
-function build(filename,target="#line") {
-    document.querySelector(target).innerHTML = build_osls(filename);
+function inject_from_file(filename, target = "#line") {
+    document.querySelector(target).innerHTML = build(filename);
 }
 
-function build_osls(filename) {
-    var xmlhttp=new XMLHttpRequest();
+function inject_from_tpl(tpl, target = "#line") {
+    document.querySelector(target).innerHTML = build_osls(document.querySelector(tpl).innerHTML);
+}
+
+function auto_build_osls() {
+    var osls_tpls = document.querySelectorAll('script[type="text/osls"]');
+    for (var i = 0; i < osls_tpls.length; i++) {
+        osls_tpls[i].parentNode.insertBefore(document.createRange().createContextualFragment(build_osls(osls_tpls[i].innerHTML)), osls_tpls[i]);
+    }
+}
+
+function download_osls(filename) {
+    var xmlhttp = new XMLHttpRequest();
     xmlhttp.open('GET', "./" + filename + ".osls", false);
     xmlhttp.send();
-    var x = xmlhttp.responseText;
-    var y = x.split("\n");
+    return xmlhttp.responseText;
+}
+
+function build_osls(osls) {
+    var y = osls.split("\n");
     var it = "";
-    y.forEach(function(ele) {
+    y.forEach(function (ele) {
         it += parse(ele);
     });
     return it;
+}
+
+function build(filename) {
+    return build_osls(download_osls(filename));
 }


### PR DESCRIPTION
# Description
new way to load osls code within the html file using <script type="text/osls"> (reducing http requests)
with auto_build_osls function you dont need to have 2 files, just write your osls code in <script type="text/osls"> tag or you can use inject_from_tpl function to do it manually. you can test it in /examples/osls_in_html.html


this pull request include changes from previous pull request if you still dont want it just ignore it but i think parsing attributes in compiler it will be necessary and load osls file in iframe is better than 2 files (reducing http requests)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
